### PR TITLE
Regex for parsing source was preventing secured videos from playing.

### DIFF
--- a/cloudflare-video-element.js
+++ b/cloudflare-video-element.js
@@ -36,7 +36,7 @@ export const VideoEvents = [
 ];
 
 const EMBED_BASE = 'https://iframe.videodelivery.net';
-const MATCH_SRC = /(?:cloudflarestream\.com|videodelivery\.net)\/(\w+)/i;
+const MATCH_SRC = /(?:cloudflarestream\.com|videodelivery\.net)\/(\S+)/i;
 const API_URL = 'https://embed.videodelivery.net/embed/sdk.latest.js';
 const API_GLOBAL = 'Stream';
 


### PR DESCRIPTION
The regex was using \W+ to match word characters, but a cloudflare stream secure token includes dashes, underscores and periods.